### PR TITLE
sqlfluff v3+ support

### DIFF
--- a/flymake-sqlfluff.el
+++ b/flymake-sqlfluff.el
@@ -115,8 +115,8 @@
 
 (defun flymake-sqlfluff-process-item (item)
   "Build a flymake diagnostic using ITEM data."
-  (let* ((line (gethash "start_line_no" item))
-         (column (gethash "start_line_pos" item))
+  (let* ((line (gethash "start_line_no" item (gethash "line_no" item)))
+         (column (gethash "start_line_pos" item (gethash "line_pos" item)))
          (code (gethash "code" item))
          (region (flymake-diag-region (current-buffer) line column))
          (description (gethash "description" item))

--- a/flymake-sqlfluff.el
+++ b/flymake-sqlfluff.el
@@ -115,8 +115,8 @@
 
 (defun flymake-sqlfluff-process-item (item)
   "Build a flymake diagnostic using ITEM data."
-  (let* ((line (gethash "line_no" item))
-         (column (gethash "line_pos" item))
+  (let* ((line (gethash "start_line_no" item))
+         (column (gethash "start_line_pos" item))
          (code (gethash "code" item))
          (region (flymake-diag-region (current-buffer) line column))
          (description (gethash "description" item))


### PR DESCRIPTION
The format of the json changed in version 3.0.0 of sqlfluff, which breaks this package. https://github.com/sqlfluff/sqlfluff/releases/tag/3.0.0

Here I just changed to the new format, though this is not backwards compatible with older versions (I suppose its possible to maintain backwards compatibility with some conditional logic, but I'm not familiar enough with elisp to write that)