### PR TITLE
Support DBT templater

### DIFF
--- a/flymake-sqlfluff.el
+++ b/flymake-sqlfluff.el
@@ -77,7 +77,7 @@
                   (shell-quote-argument flymake-sqlfluff-dialect)
                   "--format"
                   "json"
-                  "-")
+                  buffer-file-name)
         :sentinel
         (lambda (proc _event)
           ;; Check that the process has indeed exited, as it might


### PR DESCRIPTION
The DBT templater requires the file name to be specified, and can't read from stdin. Not sure if this might break some cases though...